### PR TITLE
Lisk v5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ ifeq (customCA.key,$(wildcard customCA.key))
 endif
 include $(BOLOS_SDK)/Makefile.defines
 
-APPVERSION = 2.0.2
+APPVERSION = 2.0.3
 APP_LOAD_PARAMS = --targetVersion "" --curve ed25519 $(COMMON_LOAD_PARAMS)
 ifeq ($(TARGET_NAME),TARGET_NANOX)
 APP_LOAD_PARAMS += --appFlags 0x240 # with BLE support

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ endif
 
 # Main app configuration
 
-APPNAME = "Lisk 2.0 Dev"
+APPNAME = "Lisk"
 APP_LOAD_PARAMS += --path "44'/134'"
 LEGACY_ADDRESS_SUFFIX = "L"
 LEGACY_ADDRESS_SUFFIX_LENGTH = 1

--- a/src/lisk/commands/txs/common_parser.c
+++ b/src/lisk/commands/txs/common_parser.c
@@ -60,13 +60,8 @@ void parse_group_common() {
         THROW(INVALID_PARAMETER);
       }
       transaction_memmove(txContext.senderPublicKey, txContext.bufferPointer, ENCODED_PUB_KEY);
-      // Check that is equal to what we have in the request
-      if(lisk_secure_memcmp(reqContext.account.encodedPublicKey, txContext.senderPublicKey, ENCODED_PUB_KEY) != 0) {
-        THROW(INVALID_PARAMETER);
-      }
       txContext.tx_parsing_group = TX_ASSET;
       txContext.tx_parsing_state = BEGINNING;
-
       break;
     default:
       THROW(INVALID_STATE);


### PR DESCRIPTION
The check I've removed was wrong. Indeed it's totally possible to have `senderPublicKey` different from the one derived with bip32 by the ledger, especially while signing multi-signature transactions.